### PR TITLE
mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
-    "dotenv": "^16.4.5",
     "drizzle-orm": "^0.30.9",
     "embla-carousel-react": "^8.0.2",
     "framer-motion": "^11.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ dependencies:
   cmdk:
     specifier: ^1.0.0
     version: 1.0.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
-  dotenv:
-    specifier: ^16.4.5
-    version: 16.4.5
   drizzle-orm:
     specifier: ^0.30.9
     version: 0.30.9(@libsql/client@0.6.0)(@types/react@18.2.79)(react@18.2.0)
@@ -2752,11 +2749,6 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
-
-  /dotenv@16.4.5:
-    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
-    engines: {node: '>=12'}
-    dev: false
 
   /draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}

--- a/server/db/migrate.js
+++ b/server/db/migrate.js
@@ -1,5 +1,3 @@
-import dotenv from "dotenv";
-dotenv.config();
 import { resolve, dirname } from "path";
 import { nodeDb } from "./tursoClients.js";
 import { fileURLToPath } from "url";

--- a/server/db/tursoClients.js
+++ b/server/db/tursoClients.js
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { drizzle } from "drizzle-orm/libsql";
 import { createClient as createNodeClient } from "@libsql/client";
 import { createClient as createEdgeClient } from "@libsql/client/web";


### PR DESCRIPTION
- **added choose your experience at root page and moved code editor to /ide route**
- **added cards for simple, code editor, futuristic, and 2000s**
- **code editor link disabled on mobile**
- **implemented auto complete for opening pages in code editor**
- **added name and title to choose your experience section on root page**
- **refactored root page so links are a simple ordered list, installed shadcn hover-card to show more information about linked item on root**
- **code editor list item wrapped in div to hide on small screens and show on large**
- **added not available on mobile ordered list item on root page on small screens to show code editor is available on large screens**
- **added example use of hover card on code editor link in root page**
- **projects on boring page done**
- **added index with links to div tags for nav on boring page**
- **more styling added to boring page**
- **boring page looking really good lol**
- **just need to add content for skills and blog section and write form in contact section, first going to start breakiung up /app/boring/page.tsx since it's over 250 lines**
- **abstractedf header projevts skills blogs contact and footer from /app/boring/page to cut down component line count, moved components into components/boring**
- **tweaked /components/boring/header and /projects with help from bbgirl**
- **added macOS red yellow and green buttons in ide that link back to /app/page.tsx**
- **added skills/interest section**
- **added blog, lastly need to add contact form then /app/boring/page.tsx is done**
- **Added input and textarea components**
- **added new contact form which is working to post to db, just needs styling and UI alerts on succcess and failure to user**
- **styled contact page on /app/boring/page.tsx and got alert feedback set**
- **removed dotenv package reverting to nexts env handling**
